### PR TITLE
fix: format files

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,9 +6,9 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $rules = [
-    '@Symfony' => true,
+    '@Symfony'       => true,
     '@Symfony:risky' => true,
-    'array_syntax' => [
+    'array_syntax'   => [
         'syntax' => 'short'
     ],
     'binary_operator_spaces' => [
@@ -19,32 +19,32 @@ $rules = [
     'concat_space' => [
         'spacing' => 'one'
     ],
-    'declare_strict_types' => true,
-    'global_namespace_import' => false,
+    'declare_strict_types'        => true,
+    'global_namespace_import'     => false,
     'linebreak_after_opening_tag' => true,
-    'mb_str_functions' => true,
-    'native_function_invocation' => [
+    'mb_str_functions'            => true,
+    'native_function_invocation'  => [
         'include' => [
             '@all'
         ]
     ],
-    'no_php4_constructor' => true,
-    'no_superfluous_phpdoc_tags' => false,
+    'no_php4_constructor'                   => true,
+    'no_superfluous_phpdoc_tags'            => false,
     'no_unreachable_default_argument_value' => true,
-    'no_useless_else' => true,
-    'no_useless_return' => true,
-    'ordered_imports' => true,
-    'php_unit_strict' => true,
-    'phpdoc_order' => true,
-    'semicolon_after_instruction' => true,
-    'single_import_per_statement' => false,
-    'strict_comparison' => true,
-    'strict_param' => true,
-    'single_line_throw' => false,
-    'trailing_comma_in_multiline' => false,
-    'yoda_style' => [
-        'equal' => false,
-        'identical' => false,
+    'no_useless_else'                       => true,
+    'no_useless_return'                     => true,
+    'ordered_imports'                       => true,
+    'php_unit_strict'                       => true,
+    'phpdoc_order'                          => true,
+    'semicolon_after_instruction'           => true,
+    'single_import_per_statement'           => false,
+    'strict_comparison'                     => true,
+    'strict_param'                          => true,
+    'single_line_throw'                     => false,
+    'trailing_comma_in_multiline'           => false,
+    'yoda_style'                            => [
+        'equal'            => false,
+        'identical'        => false,
         'less_and_greater' => false
     ],
 ];
@@ -59,6 +59,7 @@ $finder = Finder::create()
     ->ignoreVCS(true);
 
 $config = new Config();
+
 return $config->setFinder($finder)
     ->setRules($rules)
     ->setRiskyAllowed(true)

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ $database = Database::setInstance($databaseConf, 'primary');
 ## Examples
 For example we have a table `users` with this schema:
 
-| Field | Type | Options |
-| --- | --- | --- |
-| id | int(8) | primary key, auto increment |
-| username | varchar(255) |  |
-| ranking | int(8) |  |
+| Field    | Type         | Options                     |
+|----------|--------------|-----------------------------|
+| id       | int(8)       | primary key, auto increment |
+| username | varchar(255) |                             |
+| ranking  | int(8)       |                             |
 
 In the table we have these data:
 
 | id | username | ranking |
-| --- | --- | --- |
-| 1 | taylor | 10 |
-| 2 | alison | 30 |
-| 3 | swifts | 20 |
+|----|----------|---------|
+| 1  | taylor   | 10      |
+| 2  | alison   | 30      |
+| 3  | swifts   | 20      |
 
 ### Select methods
 The output is always an array.
@@ -187,21 +187,21 @@ $db = Database::getInstance('secondary');
 Here is the description of the array passed to the construct
 
 #### Mandatory keys
-| Parameter | Type | Description |
-| --- | --- | --- |
-| driver | string | driver of the database, it will be check with PDO::getAvailableDrivers |
-| host | string | hostname of the database (port number may be included, e.g `example.org:5342`) |
-| user | string | user used to connect to the database |
-| password | string | password used to connect to the database |
-| database | string | name of the database |
+| Parameter | Type   | Description                                                                    |
+|-----------|--------|--------------------------------------------------------------------------------|
+| driver    | string | driver of the database, it will be check with PDO::getAvailableDrivers         |
+| host      | string | hostname of the database (port number may be included, e.g `example.org:5342`) |
+| user      | string | user used to connect to the database                                           |
+| password  | string | password used to connect to the database                                       |
+| database  | string | name of the database                                                           |
 
 #### Optional keys
-| Parameter | Type | Default value | Description |
-| --- | --- | --- | --- |
-| save_queries | bool | true | all queries will be saved in memory with execution time and the connection time |
-| persistent_connection | bool | false | use persistent connection |
-| charset | string | it depends on the driver (MySQL: `utf8mb4` , PostgreSQL: `UTF8`) | set specific database charset |
-| parameters | array | [] | extra parameters used by PDO on connection |
+| Parameter             | Type   | Default value                                                    | Description                                                                     |
+|-----------------------|--------|------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| save_queries          | bool   | true                                                             | all queries will be saved in memory with execution time and the connection time |
+| persistent_connection | bool   | false                                                            | use persistent connection                                                       |
+| charset               | string | it depends on the driver (MySQL: `utf8mb4` , PostgreSQL: `UTF8`) | set specific database charset                                                   |
+| parameters            | array  | []                                                               | extra parameters used by PDO on connection                                      |
 
 ### Methods
 * createPDOConnection(): PDO
@@ -232,8 +232,8 @@ Here is the description of the array passed to the construct
 ## Database
 ### Constructor
 #### Mandatory
-| Parameter | Type | Description |
-| --- | --- | --- |
+| Parameter    | Type         | Description            |
+|--------------|--------------|------------------------|
 | configurator | Configurator | Database configuration |
 
 ### General Commands

--- a/src/Database.php
+++ b/src/Database.php
@@ -287,7 +287,7 @@ class Database
      *
      * @return mixed
      */
-    public function read(PDOStatement $statement, $fetchType = PDO::FETCH_ASSOC)
+    public function read(PDOStatement $statement, int $fetchType = PDO::FETCH_ASSOC)
     {
         return $statement->fetch($fetchType);
     }
@@ -298,7 +298,7 @@ class Database
      *
      * @return array
      */
-    public function readAll(PDOStatement $statement, $fetchType = PDO::FETCH_ASSOC): array
+    public function readAll(PDOStatement $statement, int $fetchType = PDO::FETCH_ASSOC): array
     {
         return $statement->fetchAll($fetchType);
     }

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpIllegalPsrClassPathInspection */
-
 declare(strict_types=1);
 
 namespace tests;
@@ -555,10 +553,6 @@ class ConfiguratorTest extends TestCase
         static::assertSame($expected, $conf->getParametersForPDO());
 
         $conf->setCharset('charset');
-        $expected = [
-            PDO::ATTR_ERRMODE    => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_PERSISTENT => false
-        ];
         static::assertSame($expected, $conf->getParametersForPDO());
 
         $conf->enablePersistentConnection();
@@ -591,10 +585,6 @@ class ConfiguratorTest extends TestCase
         static::assertSame($expected, $conf->getParametersForPDO());
 
         $conf->setCharset('charset');
-        $expected = [
-            PDO::ATTR_ERRMODE    => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_PERSISTENT => false
-        ];
         static::assertSame($expected, $conf->getParametersForPDO());
 
         $conf->enablePersistentConnection();

--- a/tests/DatabaseNamedInstancesTest.php
+++ b/tests/DatabaseNamedInstancesTest.php
@@ -1,7 +1,6 @@
 <?php
 
 /**
- * @noinspection PhpIllegalPsrClassPathInspection
  * @noinspection SqlDialectInspection
  */
 

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -2,7 +2,6 @@
 
 /**
  * @noinspection ForgottenDebugOutputInspection
- * @noinspection PhpIllegalPsrClassPathInspection
  * @noinspection SqlDialectInspection
  */
 
@@ -459,7 +458,6 @@ class DatabaseTest extends TestCase
         ]
     ];
 
-
     protected array $sqlFiles = [
         'mysql'  => [__DIR__ . '/test-dump-mysql.sql'],
         'pgsql'  => [__DIR__ . '/test-dump-pgsql-create-table.sql', __DIR__ . '/test-dump-pgsql-insert-table.sql'],
@@ -609,8 +607,7 @@ class DatabaseTest extends TestCase
             static::assertSame('💪', $db->selectVar('SELECT name FROM test_insert WHERE id=2'));
 
             $params = ['name' => 'C'];
-            $getLastInsertId = true;
-            $id = $db->insert($sql, $params, $getLastInsertId);
+            $id = $db->insert($sql, $params, true);
             static::assertSame(3, $id);
 
             static::assertSame(1, $db->count("SELECT COUNT(*) FROM test_insert WHERE name='C' AND id=3"));
@@ -670,8 +667,7 @@ class DatabaseTest extends TestCase
             static::assertSame(1, $db->count("SELECT COUNT(*) FROM test_update WHERE name='BB' AND id=2"));
 
             $params = ['id' => 3, 'name' => 'CC'];
-            $getCountRowsAffected = true;
-            static::assertSame(1, $db->update($sql, $params, $getCountRowsAffected));
+            static::assertSame(1, $db->update($sql, $params, true));
 
             static::assertSame(1, $db->count("SELECT COUNT(*) FROM test_update WHERE name='CC' AND id=3"));
         } catch (DatabaseException $e) {
@@ -730,8 +726,7 @@ class DatabaseTest extends TestCase
             static::assertSame(0, $db->count('SELECT COUNT(*) FROM test_delete WHERE id = 2'));
 
             $params = ['id' => 3];
-            $getCountRowsAffected = true;
-            static::assertSame(1, $db->delete($sql, $params, $getCountRowsAffected));
+            static::assertSame(1, $db->delete($sql, $params, true));
 
             static::assertSame(0, $db->count('SELECT COUNT(*) FROM test_delete WHERE id = 3'));
         } catch (DatabaseException $e) {
@@ -779,7 +774,7 @@ class DatabaseTest extends TestCase
         }
 
         $selectData = $this->selectData;
-        if (PHP_MAJOR_VERSION >= 8 && PHP_MINOR_VERSION >= 1) {
+        if (\PHP_MAJOR_VERSION >= 8 && \PHP_MINOR_VERSION >= 1) {
             $selectData = $this->selectDataPHP81;
         }
 
@@ -796,7 +791,6 @@ class DatabaseTest extends TestCase
             $data[] = $selectData[$driver][4];
             static::assertSame($data, $rows);
 
-            $sql = 'SELECT * FROM test_select WHERE ranking >= :ranking';
             $params = ['ranking' => 100];
             $rows = $db->selectAll($sql, $params);
             static::assertSame([], $rows);
@@ -845,7 +839,7 @@ class DatabaseTest extends TestCase
         }
 
         $selectData = $this->selectData;
-        if (PHP_MAJOR_VERSION >= 8 && PHP_MINOR_VERSION >= 1) {
+        if (\PHP_MAJOR_VERSION >= 8 && \PHP_MINOR_VERSION >= 1) {
             $selectData = $this->selectDataPHP81;
         }
 
@@ -859,7 +853,6 @@ class DatabaseTest extends TestCase
             $row = $db->selectRow($sql, $params);
             static::assertSame($selectData[$driver][2], $row);
 
-            $sql = 'SELECT * FROM test_select WHERE ranking >= :ranking';
             $params = ['ranking' => 100];
             $rows = $db->selectRow($sql, $params);
             static::assertSame([], $rows);
@@ -908,7 +901,7 @@ class DatabaseTest extends TestCase
         }
 
         $selectData = $this->selectData;
-        if (PHP_MAJOR_VERSION >= 8 && PHP_MINOR_VERSION >= 1) {
+        if (\PHP_MAJOR_VERSION >= 8 && \PHP_MINOR_VERSION >= 1) {
             $selectData = $this->selectDataPHP81;
         }
 
@@ -982,7 +975,7 @@ class DatabaseTest extends TestCase
         }
 
         $selectData = $this->selectData;
-        if (PHP_MAJOR_VERSION >= 8 && PHP_MINOR_VERSION >= 1) {
+        if (\PHP_MAJOR_VERSION >= 8 && \PHP_MINOR_VERSION >= 1) {
             $selectData = $this->selectDataPHP81;
         }
 
@@ -1054,7 +1047,6 @@ class DatabaseTest extends TestCase
             $statement = $db->select($sql, $params);
             static::assertSame(PDOStatement::class, \get_class($statement));
 
-            $sql = 'SELECT * FROM test_select WHERE ranking >= :ranking';
             $params = ['ranking' => 100];
             $statement = $db->select($sql, $params);
             static::assertSame(PDOStatement::class, \get_class($statement));
@@ -1091,6 +1083,7 @@ class DatabaseTest extends TestCase
      * @param string $driver
      *
      * @throws DatabaseException
+     *
      * @noinspection PhpAssignmentInConditionInspection
      */
     public function testRead(string $driver): void
@@ -1115,7 +1108,6 @@ class DatabaseTest extends TestCase
             $rows = $db->read($statement);
             static::assertCount(4, $rows);
 
-            $sql = 'SELECT * FROM test_select WHERE ranking >= :ranking';
             $params = ['ranking' => 100];
             $statement = $db->select($sql, $params);
             $row = $db->read($statement);
@@ -1167,7 +1159,6 @@ class DatabaseTest extends TestCase
             $rows = $db->readAll($statement);
             static::assertCount(3, $rows);
 
-            $sql = 'SELECT * FROM test_select WHERE ranking >= :ranking';
             $params = ['ranking' => 100];
             $statement = $db->select($sql, $params);
             $rows = $db->readAll($statement);
@@ -1233,6 +1224,7 @@ class DatabaseTest extends TestCase
      * @param string $driver
      *
      * @throws DatabaseException
+     *
      * @noinspection FopenBinaryUnsafeUsageInspection
      */
     public function testPdoParamType(string $driver): void
@@ -1256,7 +1248,7 @@ class DatabaseTest extends TestCase
 
                 $row = $db->selectRow($sql, $params);
 
-                if (PHP_MAJOR_VERSION >= 8 && PHP_MINOR_VERSION >= 1) {
+                if (\PHP_MAJOR_VERSION >= 8 && \PHP_MINOR_VERSION >= 1) {
                     static::assertSame(1, $row['true']);
                     static::assertSame(0, $row['false']);
                     static::assertSame(800, $row['int']);
@@ -1452,16 +1444,12 @@ class DatabaseTest extends TestCase
 
             $db->rollbackTransaction();
 
-            $sql = 'SELECT name FROM test_select WHERE id = :id';
-            $params = ['id' => 1];
             static::assertSame('A', $db->selectVar($sql, $params));
         } catch (DatabaseException $e) {
             \var_dump($db->getErrors());
             throw $e;
         }
 
-        $sql = 'SELECT name FROM test_select WHERE id = :id';
-        $params = ['id' => 1];
         static::assertSame('A', $db->selectVar($sql, $params));
     }
 
@@ -1544,7 +1532,6 @@ class DatabaseTest extends TestCase
                     static::assertSame('my name 1', $db->selectVar($sql, $params));
 
                     $sql = 'DELETE FROM test_select WHERE id =:id';
-                    $params = ['id' => 1];
                     $db->delete($sql, $params);
 
                     $db->rollbackTransaction();
@@ -1554,7 +1541,6 @@ class DatabaseTest extends TestCase
                 }
 
                 $sql = 'SELECT name FROM test_select WHERE id = :id';
-                $params = ['id' => 1];
                 static::assertSame('my name 1', $db->selectVar($sql, $params));
 
                 $db->commitTransaction();
@@ -1563,8 +1549,6 @@ class DatabaseTest extends TestCase
                 throw $e;
             }
 
-            $sql = 'SELECT name FROM test_select WHERE id = :id';
-            $params = ['id' => 1];
             static::assertSame('my name 1', $db->selectVar($sql, $params));
 
             $db->commitTransaction();
@@ -1573,8 +1557,6 @@ class DatabaseTest extends TestCase
             throw $e;
         }
 
-        $sql = 'SELECT name FROM test_select WHERE id = :id';
-        $params = ['id' => 1];
         static::assertSame('my name 1', $db->selectVar($sql, $params));
     }
 
@@ -1702,7 +1684,7 @@ class DatabaseTest extends TestCase
         try {
             $db->select('aaa');
             // if assert is done then it's not good
-            static::assertFalse(true);
+            static::fail();
         } catch (DatabaseException $e) {
             static::assertTrue($db->hasErrors());
             static::assertCount(4, $db->getLastError());
@@ -1977,6 +1959,7 @@ class DatabaseTest extends TestCase
      * @param string $driver
      *
      * @throws DatabaseException
+     *
      * @noinspection GetClassUsageInspection
      */
     public function testConnect(string $driver): void
@@ -2025,6 +2008,7 @@ class DatabaseTest extends TestCase
      * @param string $driver
      *
      * @throws DatabaseException
+     *
      * @noinspection GetClassUsageInspection
      */
     public function testGetPdo(string $driver): void
@@ -2054,6 +2038,7 @@ class DatabaseTest extends TestCase
      * @param string $driver
      *
      * @throws DatabaseException
+     *
      * @noinspection GetClassUsageInspection
      */
     public function testDisconnect(string $driver): void


### PR DESCRIPTION
## Description
Format files

## Changelist
- format `.php-cs-fixer.php`
- format table in `README.md`
- add type `int` to second argument for function `read` and `readAll` in `src/Database.php`
- remove useless affectation in `tests/ConfiguratorTest.php`
- remove useless affectation in `tests/DatabaseTest.php`
- remove useless `@noinspection` in `tests/ConfiguratorTest.php`
- remove useless `@noinspection` in `tests/DatabaseNamedInstancesTest.php`
- remove useless `@noinspection` in `tests/DatabaseTest.php`