### PR TITLE
chore: add php 8.5 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   test:
@@ -38,8 +39,12 @@ jobs:
       - name: Build
         run: docker compose build --build-arg PHPVERSION=${{ matrix.php-version }}
 
+      - name: Lint
+        if: matrix.php-version == '8.4'
+        run: docker compose run lib composer lint
+
       - name: Test
-        run: docker compose run -e "PHP_CS_FIXER_IGNORE_ENV=True" lib composer ci
+        run: docker compose run lib composer test
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN docker-php-ext-install \
 RUN apk add --no-cache \
     $PHPIZE_DEPS \
     linux-headers \
-    && pecl install xdebug-3.4.2 \
+    && pecl install xdebug-3.5.1 \
     && docker-php-ext-enable xdebug \
     && rm -rf /tmp/* /var/cache/apk/*
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --display-deprecation --coverage-html ./coverage --coverage-clover coverage/clover.xml"
+            "phpunit --colors --display-all-issues --coverage-html ./coverage --coverage-clover coverage/clover.xml"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --coverage-html ./coverage --coverage-clover coverage/clover.xml"
+            "phpunit --colors --display-deprecation --coverage-html ./coverage --coverage-clover coverage/clover.xml"
         ]
     }
 }

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -243,7 +243,11 @@ class Configurator
         $parameters = $this->getParameters();
 
         if ($this->getDriver() === 'mysql') {
-            $parameters[\PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES ' . $this->getCharset();
+            if (PHP_VERSION_ID >= 80500) {
+                $parameters[\Pdo\Mysql::ATTR_INIT_COMMAND] = 'SET NAMES ' . $this->getCharset();
+            } else {
+                $parameters[\PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES ' . $this->getCharset();
+            }
         }
 
         $parameters[\PDO::ATTR_ERRMODE] = \PDO::ERRMODE_EXCEPTION;

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -464,8 +464,14 @@ class ConfiguratorTest extends TestCase
 
         $conf = new Configurator($params);
 
+        if (PHP_VERSION_ID >= 80500) {
+            $parameterValueForAttrInitCommand = \Pdo\Mysql::ATTR_INIT_COMMAND;
+        } else {
+            $parameterValueForAttrInitCommand = \PDO::MYSQL_ATTR_INIT_COMMAND;
+        }
+
         $expected = [
-            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+            $parameterValueForAttrInitCommand => 'SET NAMES utf8mb4',
             \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
             \PDO::ATTR_PERSISTENT         => false
         ];
@@ -473,7 +479,7 @@ class ConfiguratorTest extends TestCase
 
         $conf->setCharset('charset');
         $expected = [
-            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES charset',
+            $parameterValueForAttrInitCommand => 'SET NAMES charset',
             \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
             \PDO::ATTR_PERSISTENT         => false
         ];
@@ -481,7 +487,7 @@ class ConfiguratorTest extends TestCase
 
         $conf->enablePersistentConnection();
         $expected = [
-            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES charset',
+            $parameterValueForAttrInitCommand => 'SET NAMES charset',
             \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
             \PDO::ATTR_PERSISTENT         => true
         ];


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
Here are some tips for you:  
1. If this PR is still in in Progress, put it in draft.
2. If this PR is introducing a breaking change please prefix with *BREAKING* in PR title.
3. If this PR has any follow up tasks, please prefix with *TODO* and describe follow up task.
4. When PR is ready to be reviewed, please tag rancoud as a sole reviewer.
-->
# Description
* add php 8.5 to test workflow
* avoid double run on github action
* add `--display-all-issues` on phpunit command
* remove lint action on php 8.5
* remove `PHP_CS_FIXER_IGNORE_ENV=True` for lint